### PR TITLE
Option to only hide replies -- not tweets on main timeline

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,10 +9,12 @@ export const App = (): JSX.Element => {
   const [allNames, setAllNames] = useState<string[]>([])
   const [currentTabId, setCurrentTabId] = useState<number>(-1)
   const [hidingEnabled, setHidingEnabled] = useState<boolean>(true)
+  const [hideRepliesOnly, setHideRepliesOnly] = useState<boolean>(false)
   const [hideGoldChecks, setHideGoldChecks] = useState<boolean>(true)
   const [hideGreyChecks, setHideGreyChecks] = useState<boolean>(true)
   const [fullyHide, setFullyHide] = useState<boolean>(false)
   const initialLoadFlagHiding = React.useRef(true)
+  const initialLoadFlagHideRepliesOnly = React.useRef(true)
   const initialLoadFlagFullyHide = React.useRef(true)
   const initialLoadFlagHideGold = React.useRef(true)
   const initialLoadFlagHideGrey = React.useRef(true)
@@ -50,6 +52,20 @@ export const App = (): JSX.Element => {
       chrome.storage.local.set({ hidingEnabled })
     }
   }, [hidingEnabled])
+
+  useEffect(() => {
+    // Save enabled state to local storage
+    if (initialLoadFlagHideRepliesOnly.current) {
+      chrome.storage.local.get('hideRepliesOnly').then((result) => {
+        if (result.hideRepliesOnly === undefined) {
+          chrome.storage.local.set({ hideRepliesOnly })
+        }
+      })
+      initialLoadFlagHideRepliesOnly.current = false
+    } else {
+      chrome.storage.local.set({ hideRepliesOnly })
+    }
+  }, [hideRepliesOnly])
 
   useEffect(() => {
     // Save enabled state to local storage
@@ -102,6 +118,13 @@ export const App = (): JSX.Element => {
         setHidingEnabled(true)
       }
     })
+    chrome.storage.local.get('hideRepliesOnly').then((result) => {
+      if (result.hideRepliesOnly !== undefined) {
+        setHideRepliesOnly(result.hideRepliesOnly)
+      } else {
+        setHideRepliesOnly(false)
+      }
+    })
     chrome.storage.local.get('fullyHide').then((result) => {
       if (result.fullyHide !== undefined) {
         setFullyHide(result.fullyHide)
@@ -141,6 +164,10 @@ export const App = (): JSX.Element => {
 
       <div style={{ padding: 12 }}>
         <ToggleSwitch onText="Don't even show the 'tweet hidden' message" offText="Don't even show the 'tweet hidden' message" handleChecked={(checked) => { setFullyHide(checked) }} checked={fullyHide} />
+      </div>
+
+      <div style={{ padding: 12 }}>
+        <ToggleSwitch onText="Applies to replies only" offText="Applies to all tweets" handleChecked={(checked) => { setHideRepliesOnly(checked) }} checked={hideRepliesOnly} />
       </div>
 
       <Accordion items={names} title={'found on this page'} />

--- a/src/chrome/content.ts
+++ b/src/chrome/content.ts
@@ -48,6 +48,7 @@
   let unhideCount = 0
 
   let shouldHide: (boolean | null) = null
+  let hideRepliesOnly: (boolean | null) = null
   let fullyHide: (boolean | null) = null
   let hideGold: (boolean | null) = null
   let hideGrey: (boolean | null) = null
@@ -56,6 +57,13 @@
     if (result.hidingEnabled !== undefined) {
       // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
       shouldHide = result.hidingEnabled
+    }
+  })
+
+  chrome.storage.local.get('hideRepliesOnly', (result) => {
+    if (result.hideRepliesOnly !== undefined) {
+      // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+      hideRepliesOnly = result.hideRepliesOnly
     }
   })
 
@@ -81,6 +89,25 @@
   })
 
   const readPage = (): void => {
+    // Check if we're on the timeline
+    if (hideRepliesOnly === true) {
+      const title = document.title
+      if (title.endsWith('Home / X')) {
+        updateStoredCheckNames(new Set<string>())
+        chrome.runtime.sendMessage(
+          {
+            from: 'content',
+            type: 'parsed-page',
+            message: { names: [] }
+          },
+          function (response) {
+            // TODO: Handle response
+          }
+        )
+        return
+      }
+    }
+
     // Detects profile page header blue check
     const UserNames = document.querySelectorAll('[data-testid="UserName"]')
     // Detects "You might like" page blue checks


### PR DESCRIPTION
the bane of bluechecks is showing up at the top of replies, poisoning every tweet's replies with garbage

i don't mind retweets of bluechecks, or bluechecks i follow (thus the benefit of this extension over the ones that unceremoniously block all bluechecks)

Separately: I also needed some changes to change `ReactDOM.render` to `createRoot` for my version of node. Let me know if you want me to submit a separate PR for that change.

<img width="488" alt="Screenshot 2023-09-17 at 9 36 39 PM" src="https://github.com/gsajith/blue-check-hider/assets/537316/42af66e1-7f2a-45f0-b0fd-7293ecded4e3">
<img width="493" alt="Screenshot 2023-09-17 at 9 36 47 PM" src="https://github.com/gsajith/blue-check-hider/assets/537316/f62441dd-ea49-4dce-a520-dbc6b20a2ff1">